### PR TITLE
chore: add reset command to purge expired tokens

### DIFF
--- a/calaos_ddns/main.go
+++ b/calaos_ddns/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/calaos/calaos_dns/utils"
 	"github.com/dghubble/sling"
 	"github.com/fatih/color"
-	"github.com/jawher/mow.cli"
+	cli "github.com/jawher/mow.cli"
 	"github.com/mattn/go-isatty"
 	"github.com/xenolf/lego/platform/config/env"
 )
@@ -66,6 +66,7 @@ func main() {
 	mnApp.Command("register", "Register a DNS record", cmdRegister)
 	mnApp.Command("unregister", "Unregister the saved DNS record", cmdUnregister)
 	mnApp.Command("update", "Update IP of DNS record", cmdUpdate)
+	mnApp.Command("reset", "Reset an expired token", cmdReset)
 
 	if _, _, err := utils.InitLogger(); err != nil {
 		exit(err, 1)
@@ -247,6 +248,19 @@ func cmdUnregister(cmd *cli.Cmd) {
 
 			color.Green(CharCheck + " Unregister successful.")
 		}
+	}
+}
+
+func cmdReset(cmd *cli.Cmd) {
+	cmd.Action = func() {
+		err := calaos.SetConfig(KEY_TOKEN, "")
+		if err != nil {
+			exit(fmt.Errorf("Failed to reset token from config:", err), 1)
+			return
+		}
+
+		color.Green(CharCheck + " Reset successful.")
+
 	}
 }
 


### PR DESCRIPTION
When a token is expired on the ddns platform, no command can be issued anymore.
Register and Unregister both lead to "Unknown token" while update print "Wrong token".

Reset command is a simple and local function that purge the ddns_token from local_config.xml so that we can register again.